### PR TITLE
chore(src): adjust examples to work with Camunda Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
-# Zeebe get start with Go client
+# Zeebe - Get Started Go Client
+
+You can find the tutorial in the [Zeebe documentation](https://docs.camunda.io/docs/product-manuals/clients/go-client/get-started).)
+
+* [Web Site](https://zeebe.io)
+* [Documentation](https://docs.camunda.io/)
+* [Issue Tracker](https://github.com/zeebe-io/zeebe/issues)
+* [Slack Channel](https://zeebe-slackin.herokuapp.com/)
+* [User Forum](https://forum.zeebe.io)
+* [Contribution Guidelines](/CONTRIBUTING.md)
+
+## Camunda Cloud Deployment
+Export the connection settings as environment variables:
+
+```
+export ZEEBE_ADDRESS='[Zeebe API]'
+export ZEEBE_CLIENT_ID='[Client ID]'
+export ZEEBE_CLIENT_SECRET='[Client Secret]'
+export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
+```
+
+**Hint:** When you create client credentials in Camunda Cloud you have the option to download a file with above lines filled out for you.
+
+Then run any example in `src`:
+
+```shell
+cd src
+go run example-4.go
+```
 
 
-You can find the tutorial in the [Zeebe documentation](https://docs.zeebe.io/clients/go-client/get-started)
-
+## Docker Deployment
 First start a broker
 
 ```shell
@@ -16,12 +43,6 @@ cd src
 go run example-4.go
 ```
 
-* [Web Site](https://zeebe.io)
-* [Documentation](https://docs.zeebe.io)
-* [Issue Tracker](https://github.com/zeebe-io/zeebe/issues)
-* [Slack Channel](https://zeebe-slackin.herokuapp.com/)
-* [User Forum](https://forum.zeebe.io)
-* [Contribution Guidelines](/CONTRIBUTING.md)
 
 ## Updating this guide
 

--- a/src/example-1.go
+++ b/src/example-1.go
@@ -5,14 +5,40 @@ import (
 	"fmt"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+	"os"
 )
 
-const BrokerAddr = "0.0.0.0:26500"
+const ZeebeAddr = "0.0.0.0:26500"
 
+/*
+Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+
+When connecting to a cluster in Camunda Cloud, this application assumes that the following
+environment variables are set:
+
+ZEEBE_ADDRESS
+ZEEBE_CLIENT_ID
+ZEEBE_CLIENT_SECRET
+ZEEBE_AUTHORIZATION_SERVER_URL
+
+Hint: When you create client credentials in Camunda Cloud you have the option
+to download a file with the lines above filled out for you.
+
+When connecting to a local cluster or node, this application assumes default port and no
+authentication or encryption enabled.
+*/
 func main() {
+	gatewayAddr := os.Getenv("ZEEBE_ADDRESS")
+	var plainText bool
+
+	if gatewayAddr == "" {
+		gatewayAddr = ZeebeAddr
+		plainText = true
+	}
+
 	zbClient, err := zbc.NewClient(&zbc.ClientConfig{
-		GatewayAddress:         BrokerAddr,
-		UsePlaintextConnection: true,
+		GatewayAddress:         gatewayAddr,
+		UsePlaintextConnection: plainText,
 	})
 
 	if err != nil {

--- a/src/example-2.go
+++ b/src/example-2.go
@@ -4,15 +4,42 @@ import (
 	"context"
 	"fmt"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+	"os"
 )
 
-const BrokerAddr = "0.0.0.0:26500"
+const ZeebeAddr = "0.0.0.0:26500"
 
+/*
+Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+
+When connecting to a cluster in Camunda Cloud, this application assumes that the following
+environment variables are set:
+
+ZEEBE_ADDRESS
+ZEEBE_CLIENT_ID
+ZEEBE_CLIENT_SECRET
+ZEEBE_AUTHORIZATION_SERVER_URL
+
+Hint: When you create client credentials in Camunda Cloud you have the option
+to download a file with the lines above filled out for you.
+
+When connecting to a local cluster or node, this application assumes default port and no
+authentication or encryption enabled.
+*/
 func main() {
+	gatewayAddr := os.Getenv("ZEEBE_ADDRESS")
+	var plainText bool
+
+	if gatewayAddr == "" {
+		gatewayAddr = ZeebeAddr
+		plainText = true
+	}
+
 	zbClient, err := zbc.NewClient(&zbc.ClientConfig{
-		GatewayAddress:         BrokerAddr,
-		UsePlaintextConnection: true,
+		GatewayAddress:         gatewayAddr,
+		UsePlaintextConnection: plainText,
 	})
+
 	if err != nil {
 		panic(err)
 	}

--- a/src/example-3.go
+++ b/src/example-3.go
@@ -4,15 +4,42 @@ import (
 	"context"
 	"fmt"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+	"os"
 )
 
-const BrokerAddr = "0.0.0.0:26500"
+const ZeebeAddr = "0.0.0.0:26500"
 
+/*
+Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+
+When connecting to a cluster in Camunda Cloud, this application assumes that the following
+environment variables are set:
+
+ZEEBE_ADDRESS
+ZEEBE_CLIENT_ID
+ZEEBE_CLIENT_SECRET
+ZEEBE_AUTHORIZATION_SERVER_URL
+
+Hint: When you create client credentials in Camunda Cloud you have the option
+to download a file with the lines above filled out for you.
+
+When connecting to a local cluster or node, this application assumes default port and no
+authentication or encryption enabled.
+*/
 func main() {
+	gatewayAddr := os.Getenv("ZEEBE_ADDRESS")
+	var plainText bool
+
+	if gatewayAddr == "" {
+		gatewayAddr = ZeebeAddr
+		plainText = true
+	}
+
 	zbClient, err := zbc.NewClient(&zbc.ClientConfig{
-		GatewayAddress:         BrokerAddr,
-		UsePlaintextConnection: true,
+		GatewayAddress:         gatewayAddr,
+		UsePlaintextConnection: plainText,
 	})
+
 	if err != nil {
 		panic(err)
 	}

--- a/src/example-4.go
+++ b/src/example-4.go
@@ -7,17 +7,44 @@ import (
 	"github.com/zeebe-io/zeebe/clients/go/pkg/worker"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
 	"log"
+	"os"
 )
 
-const BrokerAddr = "0.0.0.0:26500"
+const ZeebeAddr = "0.0.0.0:26500"
 
 var readyClose = make(chan struct{})
 
+/*
+Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+
+When connecting to a cluster in Camunda Cloud, this application assumes that the following
+environment variables are set:
+
+ZEEBE_ADDRESS
+ZEEBE_CLIENT_ID
+ZEEBE_CLIENT_SECRET
+ZEEBE_AUTHORIZATION_SERVER_URL
+
+Hint: When you create client credentials in Camunda Cloud you have the option
+to download a file with the lines above filled out for you.
+
+When connecting to a local cluster or node, this application assumes default port and no
+authentication or encryption enabled.
+*/
 func main() {
+	gatewayAddr := os.Getenv("ZEEBE_ADDRESS")
+	var plainText bool
+
+	if gatewayAddr == "" {
+		gatewayAddr = ZeebeAddr
+		plainText = true
+	}
+
 	zbClient, err := zbc.NewClient(&zbc.ClientConfig{
-		GatewayAddress:         BrokerAddr,
-		UsePlaintextConnection: true,
+		GatewayAddress:         gatewayAddr,
+		UsePlaintextConnection: plainText,
 	})
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Changes related to https://github.com/camunda-cloud/camunda-cloud-documentation/issues/89

Change set:
- Adjusts Readme to explain variant with Camunda Cloud and with local deployment
- Adjusts the examples to work with either a Camunda Cloud cluster or with a local deployment